### PR TITLE
Replace leaderboard metric from run time to combat score

### DIFF
--- a/scripts/leaderboard.gd
+++ b/scripts/leaderboard.gd
@@ -21,7 +21,7 @@ static func load_entries(path: String, max_entries: int) -> Array[Dictionary]:
 		if not _is_valid_entry(entry):
 			continue
 		leaderboard.append(entry)
-	leaderboard.sort_custom(sort_scores_ascending)
+	leaderboard.sort_custom(sort_scores_descending)
 	if leaderboard.size() > max_entries:
 		leaderboard.resize(max_entries)
 	return leaderboard
@@ -34,11 +34,11 @@ static func save_entries(path: String, leaderboard: Array[Dictionary]) -> void:
 	file.store_string(JSON.stringify(leaderboard, "  "))
 
 
-static func sort_scores_ascending(a: Dictionary, b: Dictionary) -> bool:
-	return float(a.get("time", 0.0)) < float(b.get("time", 0.0))
+static func sort_scores_descending(a: Dictionary, b: Dictionary) -> bool:
+	return int(a.get("score", 0)) > int(b.get("score", 0))
 
 
 static func _is_valid_entry(entry: Dictionary) -> bool:
-	if not entry.has("name") or not entry.has("time") or not entry.has("timestamp"):
+	if not entry.has("name") or not entry.has("score") or not entry.has("timestamp"):
 		return false
-	return typeof(entry["name"]) == TYPE_STRING and typeof(entry["timestamp"]) == TYPE_STRING and typeof(entry["time"]) in [TYPE_FLOAT, TYPE_INT]
+	return typeof(entry["name"]) == TYPE_STRING and typeof(entry["timestamp"]) == TYPE_STRING and typeof(entry["score"]) == TYPE_INT

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -242,7 +242,7 @@ func _on_victory() -> void:
 	main_menu_visible = false
 	is_paused = false
 	combat_controller.reset_runtime_entities()
-	current_message = "Victoire totale. Les 11 niveaux ont ete nettoyes en %s." % hud_controller.format_time(run_time)
+	current_message = "Victoire totale. Les 11 niveaux ont ete nettoyes. Score: %d pts." % combat_score
 	show_combat_stats = true
 	show_leaderboard = true
 	victory.emit()
@@ -319,13 +319,13 @@ func _on_submit_score_pressed() -> void:
 	if player_name.length() != 3:
 		current_message = "Entrez un nom de 3 lettres pour enregistrer la victoire."
 		return
-	leaderboard.append({"name": player_name, "time": run_time, "timestamp": Time.get_datetime_string_from_system(true)})
-	leaderboard.sort_custom(LeaderboardStore.sort_scores_ascending)
+	leaderboard.append({"name": player_name, "score": combat_score, "timestamp": Time.get_datetime_string_from_system(true)})
+	leaderboard.sort_custom(LeaderboardStore.sort_scores_descending)
 	if leaderboard.size() > GameConfig.MAX_LEADERBOARD_ENTRIES:
 		leaderboard.resize(GameConfig.MAX_LEADERBOARD_ENTRIES)
 	LeaderboardStore.save_entries(GameConfig.LEADERBOARD_PATH, leaderboard)
 	score_saved = true
-	current_message = "Score enregistre pour %s en %s." % [player_name, hud_controller.format_time(run_time)]
+	current_message = "Score enregistre pour %s: %d pts." % [player_name, combat_score]
 
 
 func _on_upgrade_selected(index: int) -> void:
@@ -367,7 +367,7 @@ func _leaderboard_text() -> String:
 		return "Aucun score enregistre."
 	var lines: Array[String] = []
 	for index in range(leaderboard.size()):
-		lines.append("%d. %s - %s" % [index + 1, leaderboard[index].get("name", "Anonyme"), hud_controller.format_time(float(leaderboard[index].get("time", 0.0)))])
+		lines.append("%d. %s - %d pts" % [index + 1, leaderboard[index].get("name", "Anonyme"), int(leaderboard[index].get("score", 0))])
 	return "\n".join(lines)
 
 


### PR DESCRIPTION
The run time was nearly fixed (11×10×30s) making it a poor ranking
metric. Switch leaderboard entries to use combat_score (int, descending)
so players are ranked by accuracy and kills instead.

- leaderboard.gd: rename sort_scores_ascending → sort_scores_descending,
  flip comparison, update _is_valid_entry to require "score" (TYPE_INT)
- main.gd: save "score" field in entry, update victory/save messages,
  update leaderboard display to show integer pts

https://claude.ai/code/session_01ThU2V77N3YftZ4X4EFyKFF