### PR TITLE
Change cruiser laser to instant beam visual

### DIFF
--- a/scripts/combat_controller.gd
+++ b/scripts/combat_controller.gd
@@ -120,7 +120,8 @@ func _update_enemies(delta: float, camels: Array[CamelEntity], base_world_pos: V
 				if position.distance_to(cruiser_target) > 4.0:
 					position += (cruiser_target - position).normalized() * enemy.speed * delta
 				if cooldown <= 0.0:
-					CombatEffects.spawn_enemy_projectile(projectile_layer, enemy_projectiles, enemy, GameEnums.ProjectileKind.LASER, 3.0, GameConfig.ENEMY_PROJECTILE_SPEED_LASER, base_world_pos)
+					_apply_damage_to_base(3.0, base_world_pos)
+					CombatEffects.spawn_enemy_laser_beam(projectile_layer, enemy_projectiles, position, base_world_pos)
 					cooldown = 1.0 / enemy.fire_rate
 			GameEnums.EnemyType.FLAGSHIP:
 				var flagship_target := Vector2(base_world_pos.x + sin(float(enemy.id) * 0.7) * 210.0, base_world_pos.y - 235.0)

--- a/scripts/combat_effects.gd
+++ b/scripts/combat_effects.gd
@@ -41,6 +41,14 @@ static func spawn_enemy_beam(projectile_layer: Node2D, enemy_projectiles: Array[
 	enemy_projectiles.append(projectile)
 
 
+static func spawn_enemy_laser_beam(projectile_layer: Node2D, enemy_projectiles: Array[ProjectileEntity], start: Vector2, end: Vector2) -> void:
+	var projectile := ProjectileEntity.new()
+	projectile.setup_beam(start, end, 0.3, GameEnums.ProjectileKind.LASER)
+	projectile.position = start
+	projectile_layer.add_child(projectile)
+	enemy_projectiles.append(projectile)
+
+
 static func spawn_enemy_tentacle_fx(projectile_layer: Node2D, enemy_projectiles: Array[ProjectileEntity], start: Vector2, base_world_pos: Vector2) -> void:
 	var projectile := ProjectileEntity.new()
 	projectile.setup_beam(start, base_world_pos + Vector2(0, -6), 0.12, GameEnums.ProjectileKind.TENTACLE)

--- a/scripts/projectile_entity.gd
+++ b/scripts/projectile_entity.gd
@@ -45,7 +45,7 @@ func setup_beam(start: Vector2, end: Vector2, beam_ttl: float, beam_kind: int) -
 
 
 func advance(delta: float) -> bool:
-	if kind == GameEnums.ProjectileKind.RAY or kind == GameEnums.ProjectileKind.TENTACLE:
+	if kind == GameEnums.ProjectileKind.RAY or kind == GameEnums.ProjectileKind.TENTACLE or kind == GameEnums.ProjectileKind.LASER:
 		ttl = max(ttl - delta, 0.0)
 		return ttl > 0.0
 	global_position += velocity * delta
@@ -79,6 +79,9 @@ func _draw_player_projectile() -> void:
 
 
 func _draw_enemy_projectile() -> void:
+	if kind == GameEnums.ProjectileKind.LASER:
+		draw_line(Vector2.ZERO, end_point - start_point, Color(1.0, 0.08, 0.08, 1.0), 2.0)
+		return
 	if kind == GameEnums.ProjectileKind.RAY:
 		_draw_saucer_beam(start_point - global_position, Vector2.ZERO)
 		return


### PR DESCRIPTION
Replace moving LASER projectile with an instant damage + 0.3s red line
beam. Damage is applied immediately on fire; the visual is a static red
line drawn from the cruiser to the base, lasting 0.3 seconds.

https://claude.ai/code/session_01VMZeThWmR1wNmezE5nPB9h